### PR TITLE
feat: salida nativa de PWM

### DIFF
--- a/rpipico/.gitignore
+++ b/rpipico/.gitignore
@@ -8,3 +8,5 @@ CMakeCache.txt
 build.ninja
 compile_commands.json
 cmake_install.cmake
+
+lib/

--- a/rpipico/pico2_tx/CMakeLists.txt
+++ b/rpipico/pico2_tx/CMakeLists.txt
@@ -57,6 +57,7 @@ target_include_directories(pico2_tx PRIVATE
 target_link_libraries(pico2_tx 
     hardware_timer
     hardware_pwm
+    hardware_clocks
 )
 
 pico_add_extra_outputs(pico2_tx)

--- a/rpipico/pico2_tx/pico2_tx.c
+++ b/rpipico/pico2_tx/pico2_tx.c
@@ -60,7 +60,7 @@ int main(void) {
     gpio_set_function(TX_GPIO, GPIO_FUNC_PWM);
     pwm_config config = pwm_get_default_config();
     slice = pwm_gpio_to_slice_num(TX_GPIO);
-    pwm_config_set_wrap(&config, 1000.0);
+    pwm_config_set_wrap(&config, 1000);
     // Interrupcion de PWM en cada wrap
     pwm_clear_irq(slice);
     pwm_set_irq_enabled(slice, true);
@@ -86,17 +86,13 @@ int main(void) {
     #endif
     	// Analizo bit a bit y cambio el PWM        
     	for(uint8_t i = 0; i < 16; i++) {
-    		// Apago el flag
-    		control.next_bit = false;
-    		// Espero a que este lista la interrupcion
-    		while(!control.next_bit);
             // Asigno el ancho de pulso segun si es 1 o 0
     		control.duty = (data & (1 << (15 - i)))? DUTY_BIT_ONE : DUTY_BIT_ZERO;
+            // Apago el flag
+            control.next_bit = false;
+            // Espero a que este lista la interrupcion
+            while(!control.next_bit);
     	}
-        // Apago el flag
-        control.next_bit = false;
-        // Espero a que este lista la interrupcion
-        while(!control.next_bit);
     
     #ifdef TRIG_GPIO
         gpio_put(TRIG_GPIO, false);

--- a/rpipico/pico2_tx/pico2_tx.c
+++ b/rpipico/pico2_tx/pico2_tx.c
@@ -1,71 +1,74 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include "hardware/timer.h"
+#include "hardware/clocks.h"
+#include "hardware/pwm.h"
 
 // GPIO por el que se envían los datos
-#define TX_GPIO     6
+#define TX_GPIO     15
 // GPIO para trigger
 #define TRIG_GPIO   16
-#define PULSE_WIDTH 4
+// Wrap para PWM (1000 ciclos de clock para 125KHz a partir de 125MHz)
+#define WRAP    1000
 
 /**
  * @brief Cantidad de microsegundos de ancho de pulso
  */
 typedef enum {
-    DUTY_BIT_ZERO = 1,
-    DUTY_NO_BIT = 2,
-    DUTY_BIT_ONE = 3
+    DUTY_BIT_ZERO = (uint16_t) (WRAP / 4),
+    DUTY_NO_BIT = (uint16_t) (WRAP / 2),
+    DUTY_BIT_ONE = (uint16_t) (3 * WRAP / 4)
 } duty_us_t;
 
 /**
  * Estructura de control para la trama de datos
  */
 typedef struct {
-    uint8_t duty;       // Marca para el ancho de pulso
-    bool next_bit;      // Booleano para habilitar el siguiente bit
+    uint16_t duty;  // Marca para el ancho de pulso
+    bool next_bit;  // Booleano para habilitar el siguiente bit
 } duty_control_t;
 
+// Numero de slice de PWM
+uint32_t slice;
+// Estructura de control para la trama de datos
+volatile duty_control_t control = { .duty = DUTY_NO_BIT, .next_bit = false };
+
 /**
- * @brief Interrupcion de timer
+ * @brief Interrupcion de wrap de PWM
  */
-bool timer_cb(repeating_timer_t *t) {
-    // Cantidad de interrupciones
-    static uint8_t count = 0;
-    // Estructura local de control
-    duty_control_t *control = (duty_control_t*)(t->user_data);
-    // Apaga la salida cuando se cumple el duty
-    if(count == control->duty)
-        gpio_put(TX_GPIO, false);
-    else if(count == 4) {
-        // Prendo la salida cuando se tiene que resetear el ciclo
-        gpio_put(TX_GPIO, true);
-        // Reseteo variables de control
-        control->next_bit = true;
-        count = 0;
-    }
-    // Incremento contador de interrupciones
-    count++;
-    // Sigue el timer
-    return true;
+void on_wrap(void) {
+    // Limpio flag
+    pwm_clear_irq(slice);
+    // Cambio el duty cicle y destrabo main
+    pwm_set_gpio_level(TX_GPIO, control.duty);
+    control.next_bit = true;
 }
 
 /**
  * @brief Programa principal
  */
 int main(void) {
-
+    // Clock del sistema en 125MHz
+    set_sys_clock_khz(125000, true);
     stdio_init_all();
+
     uint16_t test_data[4] = {0xa796, 0xabcd, 0x1234, 0x5678};
     uint8_t test_data_index = 0;
     uint16_t data;
-    // Timer para generar las interrupciones
-    repeating_timer_t timer;
-    // Estructura de control para la trama de datos
-    volatile duty_control_t control = { .duty = DUTY_NO_BIT, .next_bit = false };
 
-    gpio_init(TX_GPIO);
-    gpio_set_dir(TX_GPIO, true);
-    gpio_put(TX_GPIO, false);
+    // Inicializacion de PWM a 125KHz
+    gpio_set_function(TX_GPIO, GPIO_FUNC_PWM);
+    pwm_config config = pwm_get_default_config();
+    slice = pwm_gpio_to_slice_num(TX_GPIO);
+    pwm_config_set_wrap(&config, 1000.0);
+    // Interrupcion de PWM en cada wrap
+    pwm_clear_irq(slice);
+    pwm_set_irq_enabled(slice, true);
+    irq_set_exclusive_handler(PWM_DEFAULT_IRQ_NUM(), on_wrap);
+    irq_set_enabled(PWM_DEFAULT_IRQ_NUM(), true);
+    // Arranca a actuar el PWM
+    pwm_init(slice, &config, true);
+    pwm_set_gpio_level(TX_GPIO, DUTY_NO_BIT);
 
 #ifdef TRIG_GPIO
     // GPIO para ayudar al trigger del osciloscopio
@@ -74,14 +77,9 @@ int main(void) {
     gpio_put(TRIG_GPIO, false);
 #endif
 
-    // Timer cada 2us, comparte estructura de control
-    add_repeating_timer_us(-PULSE_WIDTH, timer_cb, (void*) &control, &timer);
-
     while(1) {
     	// Trama de datos de prueba
     	data = test_data[test_data_index];
-    	// 1	0	1	0	0	1	1	1	1 	0 	0 	1 	0 	1 	1 	0
-    	// 75%	25%	75%	25%	25%	75%	75%	75%	75%	25%	25%	75%	25%	75%	75%	25%
 
     #ifdef TRIG_GPIO
         gpio_put(TRIG_GPIO, true);

--- a/rpipico/pico2_tx/pico2_tx.c
+++ b/rpipico/pico2_tx/pico2_tx.c
@@ -100,8 +100,12 @@ int main(void) {
     
         // Fin de trama
         control.duty = DUTY_NO_BIT;
+        // Apago el flag
+        control.next_bit = false;
+        // Espero a que este lista la interrupcion
+        while(!control.next_bit);
         test_data_index = (test_data_index + 1) % 4;
-        sleep_ms(1);
+        sleep_ms(5);
     }
     return 0;
 }


### PR DESCRIPTION
Cambié las interrupciones por Timer cada 2us a el uso de la interrupción por wrap de PWM para que se resuelva por hardware el cambio de duty cycle sin necesidad de consumir tanto recurso del CPU.

El resultado fue satisfactorio 👍🏻 